### PR TITLE
merge operator opts: log_softmax, take, where, log, split

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ endif
 ifeq ($(DEBUG), 1)
 	CFLAGS += -g -O0
 else
-	CFLAGS += -O3 -DNDEBUG=1
+	CFLAGS += -O3 -DNDEBUG=1 -march=native
 endif
 CFLAGS += -I$(TPARTYDIR)/mshadow/ -I$(TPARTYDIR)/dmlc-core/include -fPIC -I$(NNVM_PATH)/include -I$(DLPACK_PATH)/include -I$(TPARTYDIR)/tvm/include -Iinclude $(MSHADOW_CFLAGS)
 LDFLAGS = -pthread $(MSHADOW_LDFLAGS) $(DMLC_LDFLAGS)

--- a/src/operator/channel_op_common.h
+++ b/src/operator/channel_op_common.h
@@ -101,6 +101,43 @@ void Split(const mshadow::Tensor<xpu, dim, DType> &input,
     split_helper<xpu, dim, dim-1>(input, output, dimension, req);
   }
 }
+
+template<typename xpu, int dim, typename DType>
+void Split_2D(const mshadow::Tensor<xpu, dim, DType> &input,
+           std::vector<mshadow::Tensor<xpu, dim, DType> > *output,
+           const int dimension, const std::vector<OpReqType> &req) {
+  if (dimension != 1) {
+    LOG(FATAL) << "dimension (" << dimension << ") must == 1";
+  }
+  if (dim != 3) {
+    LOG(FATAL) << "dimension (" << dim << ") must == 3";
+  } else {
+    std::vector<mshadow::Tensor<xpu, dim, DType> > out = *output;
+    size_t size = out.size();
+    std::vector<int>slice_len;
+    std::vector<int>begin_pos;
+    begin_pos.push_back(0);
+
+    for (index_t i = 0; i < size; ++i) {
+      slice_len.push_back(out[i].size(dimension));
+      begin_pos.push_back(begin_pos[i] + out[i].size(dimension));
+    }
+#if !defined(MXNET_ENABLE_CUDA_RTC)
+    #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
+#endif
+    for (int i = 0; i < input.shape_[0]; i++) {
+      int iRow = i*input.shape_[1];
+      for (int j = 0; j < size; j++) {
+        int jRow = i*slice_len[j];
+        int iPos = iRow + begin_pos[j];
+        for (int k = 0; k < slice_len[j]; k++) {
+          out[j].dptr_[jRow + k] = input.dptr_[iPos + k];
+        }
+      }
+    }
+  }
+}
+
 }  // namespace op
 }  // namespace mxnet
 #endif  // MXNET_OPERATOR_CHANNEL_OP_COMMON_H_

--- a/src/operator/nn/softmax-inl.h
+++ b/src/operator/nn/softmax-inl.h
@@ -31,6 +31,10 @@
 #include "../operator_common.h"
 #include "../tensor/broadcast_reduce_op.h"
 
+#if MSHADOW_USE_MKL == 1
+#include "mkl.h"
+#endif
+
 namespace mxnet {
 namespace op {
 namespace mxnet_op {
@@ -41,7 +45,6 @@ struct softmax_fwd {
     return DType(expf(a)/b);
   }
 };
-
 
 struct log_softmax_fwd {
   template<typename DType>
@@ -310,6 +313,54 @@ void SoftmaxCompute(const nnvm::NodeAttrs& attrs,
   });
 }
 
+#if MSHADOW_USE_MKL == 1
+static inline int64_t prod(int64_t* n, int start, int end) {
+  int64_t res = 1;
+  for (int i = start; i < end; i++)
+    res *= n[i];
+  return res;
+}
+
+static inline void max_(int64_t n, float * __restrict__ in, float *dst) {
+  dst[0] = in[0];
+  for (int64_t i = 1; i < n; i++)
+    dst[0] = (dst[0] < in[i]) ? in[i] : dst[0];
+}
+
+static inline void sub_(int64_t n, float * __restrict__ in, float b, float * __restrict__ dst) {
+  for (int64_t i = 0; i < n; i++)
+    dst[i] = in[i] - b;
+}
+
+static inline void sum_(int64_t n, float * __restrict__ in, float * __restrict__ dst) {
+  dst[0] = cblas_sasum(n, in, 1);
+}
+
+static inline void exp_(int64_t n, float *in, float *dst) {
+  vsExp(n, in, dst);
+}
+
+static inline void log_softmax_parallel(TShape sh, int axis,
+                                        float * __restrict__ in, float * __restrict__ out) {
+  int64_t outer_size = prod(sh.data(), 0, axis);
+  int64_t channels = sh[axis];
+  // int inner_size = prod(n, axis+1, 4);
+
+#pragma omp parallel for
+  for (int ou=0; ou < outer_size; ou++) {
+    float *in_dat = in + ou * channels;
+    float *out_dat = out + ou * channels;
+    float b, logsum;
+
+    max_(channels, in_dat, &b);
+    sub_(channels, in_dat, b, out_dat);
+    exp_(channels, out_dat, out_dat);
+    sum_(channels, out_dat, &logsum);
+    logsum = b + logf(logsum);
+    sub_(channels, in_dat, logsum, out_dat);
+  }
+}
+#endif
 
 template<typename xpu, typename OP1, typename OP2, bool negate = false>
 void SoftmaxGradCompute(const nnvm::NodeAttrs& attrs,

--- a/src/operator/nn/softmax-inl.h
+++ b/src/operator/nn/softmax-inl.h
@@ -346,7 +346,7 @@ static inline void log_softmax_parallel(TShape sh, int axis,
   int64_t channels = sh[axis];
   // int inner_size = prod(n, axis+1, 4);
 
-#pragma omp parallel for
+#pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
   for (int ou=0; ou < outer_size; ou++) {
     float *in_dat = in + ou * channels;
     float *out_dat = out + ou * channels;

--- a/src/operator/slice_channel-inl.h
+++ b/src/operator/slice_channel-inl.h
@@ -99,7 +99,12 @@ class SliceChannelOp : public Operator {
     for (int i = 0; i < size_; ++i) {
       outputs[i] = out_data[i].get_with_shape<xpu, 3, DType>(slice_shape, s);
     }
-    Split(data, &outputs, 1, req);
+    // 3D dshape and trailing==1, split_2d can be used to speedup
+    if (trailing == 1 && std::is_same<xpu, cpu>::value) {
+      Split_2D(data, &outputs, 1, req);
+    } else {
+      Split(data, &outputs, 1, req);
+    }
   }
 
   virtual void Backward(const OpContext &ctx,

--- a/src/operator/tensor/elemwise_unary_op.h
+++ b/src/operator/tensor/elemwise_unary_op.h
@@ -29,11 +29,15 @@
 #include <vector>
 #include <utility>
 #include <algorithm>
+#include <climits>
 #include "./cast_storage-inl.h"
 #include "../mshadow_op.h"
 #include "../mxnet_op.h"
 #include "../elemwise_op_common.h"
 #include "../../ndarray/ndarray_function.h"
+#if MSHADOW_USE_MKL == 1
+#include "mkl.h"
+#endif
 
 namespace mxnet {
 namespace op {
@@ -347,6 +351,43 @@ class UnaryOp : public OpBase {
     } else {
       LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
     }
+  }
+
+#if MSHADOW_USE_MKL == 1
+  static inline void MKLLog(MKL_INT size, const float* pIn, float* pOut) {
+    vsLn(size, pIn, pOut);
+  }
+
+  static inline void MKLLog(MKL_INT size, const double* pIn, double* pOut) {
+    vdLn(size, pIn, pOut);
+  }
+#endif
+
+  template<typename xpu, typename OP>
+  static void LogCompute(const nnvm::NodeAttrs& attrs,
+                         const OpContext& ctx,
+                         const std::vector<TBlob>& inputs,
+                         const std::vector<OpReqType>& req,
+                         const std::vector<TBlob>& outputs) {
+    if (req[0] == kNullOp) return;
+    // if defined MSHADOW_USE_MKL then call mkl log when req is KWriteTo, type_flag
+    // is mshadow::kFloat32 or mshadow::kFloat64 and data size less than or equal MKL_INT_MAX
+#if MSHADOW_USE_MKL == 1
+    auto type_flag = inputs[0].type_flag_;
+    const size_t MKL_INT_MAX = (sizeof(MKL_INT) == sizeof(int)) ? INT_MAX : LLONG_MAX;
+    size_t input_size = inputs[0].Size();
+    if (req[0] == kWriteTo &&
+        input_size <= MKL_INT_MAX &&
+        (type_flag == mshadow::kFloat32 || type_flag == mshadow::kFloat64)) {
+      MSHADOW_SGL_DBL_TYPE_SWITCH(type_flag, DType, {
+        MKLLog(input_size, inputs[0].dptr<DType>(), outputs[0].dptr<DType>());
+      });
+    } else {
+      Compute<xpu, OP>(attrs, ctx, inputs, req, outputs);
+    }
+#else
+    Compute<xpu, OP>(attrs, ctx, inputs, req, outputs);
+#endif
   }
 };
 

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -940,7 +940,7 @@ The storage type of ``exp`` output is always dense
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseOut{"_mul"});
 
 // log
-MXNET_OPERATOR_REGISTER_UNARY_WITH_SPARSE_DR(log, cpu, mshadow_op::log)
+MXNET_OPERATOR_REGISTER_UNARY(log)
 MXNET_ADD_SPARSE_OP_ALIAS(log)
 .describe(R"code(Returns element-wise Natural logarithmic value of the input.
 
@@ -949,6 +949,7 @@ The natural logarithm is logarithm in base *e*, so that ``log(exp(x)) = x``
 The storage type of ``log`` output is always dense
 
 )code" ADD_FILELINE)
+.set_attr<FCompute>("FCompute<cpu>", UnaryOp::LogCompute<cpu, mshadow_op::log>)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_log"});
 
 // log10

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -295,11 +295,15 @@ void TakeOpForward<cpu>(const nnvm::NodeAttrs& attrs,
     MSHADOW_TYPE_SWITCH(inputs[1].type_flag_, IType, {  // index data type
       if (actual_axis == 0) {
         if (param.mode == take_::kClip) {
-          Kernel<TakeCPU<true>, cpu>::Launch(s, idxshape.Size(),
-                                             outputs[take_::kOut].dptr<DType>(),
-                                             inputs[take_::kArr].dptr<DType>(),
-                                             inputs[take_::kIdx].dptr<IType>(),
-                                             oshape.Size()/idxshape.Size(), arrshape[0]);
+          take_axis0_clip_func(outputs[take_::kOut].dptr<DType>(),
+                               inputs[take_::kArr].dptr<DType>(),
+                               inputs[take_::kIdx].dptr<IType>(),
+                               idxshape[0], oshape.Size()/idxshape.Size(), arrshape[0]);
+          // Kernel<TakeCPU<true>, cpu>::Launch(s, idxshape.Size(),
+          //                                    outputs[take_::kOut].dptr<DType>(),
+          //                                    inputs[take_::kArr].dptr<DType>(),
+          //                                    inputs[take_::kIdx].dptr<IType>(),
+          //                                    oshape.Size()/idxshape.Size(), arrshape[0]);
         } else {
           Kernel<TakeCPU<false>, cpu>::Launch(s, idxshape.Size(),
                                               outputs[take_::kOut].dptr<DType>(),


### PR DESCRIPTION
## Description ##
Merge optimizations from opt-1.3.1 branch, including: 

- log_softmax
- take
- where
- log
- split

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
